### PR TITLE
fix children types for preact

### DIFF
--- a/packages/preact/src/consumer.ts
+++ b/packages/preact/src/consumer.ts
@@ -18,7 +18,7 @@ type GrafooRenderFn<T, U> = (renderProps: GrafooBoundState & T & GrafooBoundMuta
  * U = Mutations
  */
 type GrafooPreactConsumerProps<T = {}, U = {}> = GrafooConsumerProps<T, U> & {
-  children?: [GrafooRenderFn<T, U>];
+  children?: GrafooRenderFn<T, U>;
 };
 
 /**

--- a/packages/preact/src/provider.ts
+++ b/packages/preact/src/provider.ts
@@ -1,7 +1,7 @@
 import { Context } from "@grafoo/types";
 import { Component } from "preact";
 
-type GrafooPreactProviderProps = Context & { children?: [JSX.Element] };
+type GrafooPreactProviderProps = Context & { children?: JSX.Element };
 
 export class Provider extends Component<GrafooPreactProviderProps> {
   getChildContext(): Context {


### PR DESCRIPTION
In preact releases prior to 8.3 children prop wasn't correctly assigned. This pr fixes the issue.