### PR TITLE
Various improvements

### DIFF
--- a/packages/babel-plugin/__tests__/compile-document.js
+++ b/packages/babel-plugin/__tests__/compile-document.js
@@ -43,4 +43,33 @@ describe("compile document", () => {
 
     expect(() => transform(program)).not.toThrow();
   });
+
+  it("should accept named queries", () => {
+    const program = `
+      import gql from "@grafoo/core/tag";
+      const query = gql\`
+        query NamedQuery {
+          me { id }
+        }
+      \`;
+    `;
+
+    expect(() => transform(program)).not.toThrow();
+  });
+
+  it("should accept named queries with arguments", () => {
+    const program = `
+      import gql from "@grafoo/core/tag";
+      const query = gql\`
+        query NamedQuery($var: ID!) {
+          post(id: $var) {
+            id
+            title
+          }
+        }
+      \`;
+    `;
+
+    expect(() => transform(program)).not.toThrow();
+  });
 });

--- a/packages/babel-plugin/__tests__/insert-fields.js
+++ b/packages/babel-plugin/__tests__/insert-fields.js
@@ -217,6 +217,36 @@ const cases = [
     idFields: ["bio"]
   },
   {
+    should: "should insert fields in inline fragments while leaving unions",
+    input: `
+      {
+        viewer {
+          ...on Visitor {
+            ip
+          }
+          ...on User {
+            username
+          }
+        }
+      }
+    `,
+    expectedOutput: `
+      {
+        viewer {
+          ...on Visitor {
+            ip
+            id
+          }
+          ...on User {
+            username
+            id
+          }
+        }
+      }
+    `,
+    idFields: ["id"]
+  },
+  {
     should: "should not insert `__typename` in an operation definition",
     input: `
       mutation createPost($title: Int!, $body: Int!, $id: ID! $authors: [ID!]!) {

--- a/packages/babel-plugin/__tests__/schema.graphql
+++ b/packages/babel-plugin/__tests__/schema.graphql
@@ -28,7 +28,10 @@ type Query {
   users(start: Int!, offset: Int!): [User]
   user(id: ID!): User
   me: User
+  viewer: Viewer
 }
+
+union Viewer = Visitor | User
 
 type Tag {
   id: ID!
@@ -50,4 +53,9 @@ type Author implements User {
   name: String
   bio: String
   posts: [Post!]!
+}
+
+type Visitor {
+  id: ID!
+  ip: String!
 }

--- a/packages/babel-plugin/src/compile-document.js
+++ b/packages/babel-plugin/src/compile-document.js
@@ -20,10 +20,10 @@ function getSchema(schemaPath) {
       fullPath = fs.existsSync(schemaJson)
         ? schemaJson
         : fs.existsSync(schemaGraphql)
-          ? schemaGraphql
-          : fs.existsSync(schemaGql)
-            ? schemaGql
-            : undefined;
+        ? schemaGraphql
+        : fs.existsSync(schemaGql)
+        ? schemaGql
+        : undefined;
     } else {
       fullPath = path.join(process.cwd(), schemaPath);
     }
@@ -56,7 +56,12 @@ export default function compileDocument(source, opts) {
         Object.assign(acc, {
           [compress(print(s))]: {
             name: s.name.value,
-            args: s.arguments.map(a => a.name.value)
+            args: s.arguments.map(a => {
+              if (a.value && a.value.kind === "Variable") {
+                a = a.value;
+              }
+              return a.name.value;
+            })
           }
         }),
       {}

--- a/packages/babel-plugin/src/insert-fields.js
+++ b/packages/babel-plugin/src/insert-fields.js
@@ -47,20 +47,18 @@ export default function insertFields(schemaStr, documentAst, idFields) {
       );
 
       for (const field of idFields) {
-        const fieldIsNotDeclared = selections.some(_ => _.name.value !== field);
-        const fieldIsTypename = field === "__typename";
+        if (selections.some(_ => _.name && _.name.value === field)) {
+          continue; // Skip already declared fields
+        }
+
         const typeHasField = typeFields.some(_ => _ === field);
         const typeInterfacesHasField = typeInterfacesFields.some(_ => _ === field);
 
-        if (fieldIsTypename && fieldIsNotDeclared && !isFragment) {
-          insertField(selections, field);
-        }
-
-        if (fieldIsNotDeclared && typeInterfacesHasField && !isFragment) {
-          insertField(selections, field);
-        }
-
-        if (fieldIsNotDeclared && typeHasField) {
+        if (
+          typeHasField ||
+          (field === "__typename" && !isFragment) ||
+          (typeInterfacesHasField && !isFragment)
+        ) {
           insertField(selections, field);
         }
       }

--- a/packages/babel-plugin/src/insert-fields.js
+++ b/packages/babel-plugin/src/insert-fields.js
@@ -34,6 +34,11 @@ export default function insertFields(schemaStr, documentAst, idFields) {
       }
 
       const type = getType(typeInfo);
+
+      if (type.astNode.kind === "UnionTypeDefinition") {
+        return;
+      }
+
       const typeFields = Object.keys(type.getFields());
       const typeInterfaces = type.getInterfaces ? type.getInterfaces() : [];
       const typeInterfacesFields = typeInterfaces.reduce(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,5 +102,10 @@ export default function createClient(
     return { objectsMap, pathsMap };
   }
 
-  return { execute, listen, write, read, flush };
+  function reset() {
+    pathsMap = {};
+    objectsMap = {};
+  }
+
+  return { execute, listen, write, read, flush, reset };
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -62,6 +62,7 @@ export interface GrafooClient {
     variables?: Variables
   ) => { data?: T; objects?: ObjectsMap; partial?: boolean };
   flush: () => InitialState;
+  reset: () => void;
 }
 
 export interface GrafooClientOptions {

--- a/readme.md
+++ b/readme.md
@@ -123,11 +123,19 @@ const USER_QUERY = gql`
 
 const variables = { id: 123 };
 
-client.request(USER_QUERY, variables).then(data => {
+client.execute(USER_QUERY, variables).then(data => {
+  // Write to cache
   client.write(USER_QUERY, variables, data);
 
+  // Do whatever with returned data
+  console.log(data);
+
+  // Read from cache at a later stage
   console.log(client.read(USER_QUERY, variables));
 });
+
+// If you wish to reset (clear) the cache:
+client.reset();
 ```
 
 ### With a framework


### PR DESCRIPTION
Hi @malbernaz! I really like the advertised features and scope of this project. Currently experimenting with it to see if it can fulfil the needs for an incremental GraphQL rollout for a complex React SPA over at @soundtrackyourbrand. I'm curious if you're actively using this project yourself, and/or still planning on maintaining this project? If we end up using this I'll be more than happy to contribute back any bug fixes and improvements as long as someone is interested in receiving them.

This PR contains fixes to some issues I discovered while trying out the library. If you think they're relevant I'll write some tests for the affected code and update the docs before requesting a merge.

## Correctly identify variables in arguments

The babel-plugin didn't seem to be able to identify variables correctly. In the following example it would consider `id` being the variable to cache by, instead of `variable`:

```js
const QUERY = gql`
  query CustomQuery($variable: ID!) {
    lookup(id: $variable) { ... }
  }
`
```

## Don't throw error when encountering a Union node

The following query would throw an error:

```js
const QUERY = gql`
  query AccountsForUser {
    me { # Error thrown here
      ...on User { ... }
    }
  }
`
```

Schema:
```graphql
type RootQueryType {
  me: Viewer
}

union Viewer = User | PublicAPIClient
```

## Prevent multiple instances of idFields to be added to the same node

Tweaked the logic that adds the idFields to avoid adding duplicates of the idFields to the queries. Can be solved changing the `if` chain into `else if`, but I included some additional code style rewrites (feel free to skip these).

## Add client.reset() which clears cache

There was no way to reset the cache, which can be useful to do when a user logs out or similar.