### PR TITLE
Generate and add id to query object

### DIFF
--- a/packages/babel-plugin/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin/__tests__/__snapshots__/index.js.snap
@@ -19,8 +19,42 @@ const query = gql\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const query = {
-  \\"id\\": \\"04b0684748bc044e1f86d366ecbc70dd6e59b99c65671e853f9ecd0b836eaeaf\\",
   \\"query\\": \\"query($id:ID!,$offset:Int!,$start:Int!){posts(offset:$offset,start:$start){authors{id name username}body createdAt id tags{id name}title}user(id:$id){id name username}}\\",
+  \\"paths\\": {
+    \\"posts(offset:$offset,start:$start){authors{id name username}body createdAt id tags{id name}title}\\": {
+      \\"name\\": \\"posts\\",
+      \\"args\\": [\\"offset\\", \\"start\\"]
+    },
+    \\"user(id:$id){id name username}\\": {
+      \\"name\\": \\"user\\",
+      \\"args\\": [\\"id\\"]
+    }
+  }
+};
+"
+`;
+
+exports[`@grafoo/babel-plugin should generate md5 hash and add it to object if the option generateIds is specified: should generate md5 hash and add it to object if the option generateIds is specified 1`] = `
+"
+import gql from \\"@grafoo/core/tag\\";
+const query = gql\`
+  query($start: Int!, $offset: Int!, $id: ID!) {
+    posts(start: $start, offset: $offset) {
+      title
+      body
+      createdAt
+      tags { name }
+      authors { name username }
+    }
+    user(id: $id) { name username }
+  }
+\`;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const query = {
+  \\"id\\": \\"6e0697df8f2453f2643bbd1e8a39c348\\",
+  \\"query\\": \\"query ($id: ID!, $offset: Int!, $start: Int!) {\\\\n  posts(offset: $offset, start: $start) {\\\\n    authors {\\\\n      id\\\\n      name\\\\n      username\\\\n    }\\\\n    body\\\\n    createdAt\\\\n    id\\\\n    tags {\\\\n      id\\\\n      name\\\\n    }\\\\n    title\\\\n  }\\\\n  user(id: $id) {\\\\n    id\\\\n    name\\\\n    username\\\\n  }\\\\n}\\",
   \\"paths\\": {
     \\"posts(offset:$offset,start:$start){authors{id name username}body createdAt id tags{id name}title}\\": {
       \\"name\\": \\"posts\\",
@@ -98,6 +132,40 @@ const query = createClient(someTransport, options);
 "
 `;
 
+exports[`@grafoo/babel-plugin should not generate md5 hash and add it to object if the option generateIds is falsey: should not generate md5 hash and add it to object if the option generateIds is falsey 1`] = `
+"
+import gql from \\"@grafoo/core/tag\\";
+const query = gql\`
+  query($start: Int!, $offset: Int!, $id: ID!) {
+    posts(start: $start, offset: $offset) {
+      title
+      body
+      createdAt
+      tags { name }
+      authors { name username }
+    }
+    user(id: $id) { name username }
+  }
+\`;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const query = {
+  \\"query\\": \\"query ($id: ID!, $offset: Int!, $start: Int!) {\\\\n  posts(offset: $offset, start: $start) {\\\\n    authors {\\\\n      id\\\\n      name\\\\n      username\\\\n    }\\\\n    body\\\\n    createdAt\\\\n    id\\\\n    tags {\\\\n      id\\\\n      name\\\\n    }\\\\n    title\\\\n  }\\\\n  user(id: $id) {\\\\n    id\\\\n    name\\\\n    username\\\\n  }\\\\n}\\",
+  \\"paths\\": {
+    \\"posts(offset:$offset,start:$start){authors{id name username}body createdAt id tags{id name}title}\\": {
+      \\"name\\": \\"posts\\",
+      \\"args\\": [\\"offset\\", \\"start\\"]
+    },
+    \\"user(id:$id){id name username}\\": {
+      \\"name\\": \\"user\\",
+      \\"args\\": [\\"id\\"]
+    }
+  }
+};
+"
+`;
+
 exports[`@grafoo/babel-plugin should overide \`idFields\` in the client instantiation if options is a variable: should overide \`idFields\` in the client instantiation if options is a variable 1`] = `
 "
 import createClient from \\"@grafoo/core\\";
@@ -143,7 +211,6 @@ const query = gql\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const query = {
-  \\"id\\": \\"04b0684748bc044e1f86d366ecbc70dd6e59b99c65671e853f9ecd0b836eaeaf\\",
   \\"query\\": \\"query ($id: ID!, $offset: Int!, $start: Int!) {\\\\n  posts(offset: $offset, start: $start) {\\\\n    authors {\\\\n      id\\\\n      name\\\\n      username\\\\n    }\\\\n    body\\\\n    createdAt\\\\n    id\\\\n    tags {\\\\n      id\\\\n      name\\\\n    }\\\\n    title\\\\n  }\\\\n  user(id: $id) {\\\\n    id\\\\n    name\\\\n    username\\\\n  }\\\\n}\\",
   \\"paths\\": {
     \\"posts(offset:$offset,start:$start){authors{id name username}body createdAt id tags{id name}title}\\": {

--- a/packages/babel-plugin/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin/__tests__/__snapshots__/index.js.snap
@@ -19,6 +19,7 @@ const query = gql\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const query = {
+  \\"id\\": \\"04b0684748bc044e1f86d366ecbc70dd6e59b99c65671e853f9ecd0b836eaeaf\\",
   \\"query\\": \\"query($id:ID!,$offset:Int!,$start:Int!){posts(offset:$offset,start:$start){authors{id name username}body createdAt id tags{id name}title}user(id:$id){id name username}}\\",
   \\"paths\\": {
     \\"posts(offset:$offset,start:$start){authors{id name username}body createdAt id tags{id name}title}\\": {
@@ -142,6 +143,7 @@ const query = gql\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const query = {
+  \\"id\\": \\"04b0684748bc044e1f86d366ecbc70dd6e59b99c65671e853f9ecd0b836eaeaf\\",
   \\"query\\": \\"query ($id: ID!, $offset: Int!, $start: Int!) {\\\\n  posts(offset: $offset, start: $start) {\\\\n    authors {\\\\n      id\\\\n      name\\\\n      username\\\\n    }\\\\n    body\\\\n    createdAt\\\\n    id\\\\n    tags {\\\\n      id\\\\n      name\\\\n    }\\\\n    title\\\\n  }\\\\n  user(id: $id) {\\\\n    id\\\\n    name\\\\n    username\\\\n  }\\\\n}\\",
   \\"paths\\": {
     \\"posts(offset:$offset,start:$start){authors{id name username}body createdAt id tags{id name}title}\\": {

--- a/packages/babel-plugin/__tests__/index.js
+++ b/packages/babel-plugin/__tests__/index.js
@@ -103,6 +103,51 @@ pluginTester({
       `,
       snapshot: true
     },
+    "should generate md5 hash and add it to object if the option generateIds is specified": {
+      pluginOptions: {
+        schema: "__tests__/schema.graphql",
+        idFields: ["id"],
+        generateIds: true
+      },
+      code: `
+        import gql from "@grafoo/core/tag";
+        const query = gql\`
+          query($start: Int!, $offset: Int!, $id: ID!) {
+            posts(start: $start, offset: $offset) {
+              title
+              body
+              createdAt
+              tags { name }
+              authors { name username }
+            }
+            user(id: $id) { name username }
+          }
+        \`;
+      `,
+      snapshot: true
+    },
+    "should not generate md5 hash and add it to object if the option generateIds is falsey": {
+      pluginOptions: {
+        schema: "__tests__/schema.graphql",
+        idFields: ["id"]
+      },
+      code: `
+        import gql from "@grafoo/core/tag";
+        const query = gql\`
+          query($start: Int!, $offset: Int!, $id: ID!) {
+            posts(start: $start, offset: $offset) {
+              title
+              body
+              createdAt
+              tags { name }
+              authors { name username }
+            }
+            user(id: $id) { name username }
+          }
+        \`;
+      `,
+      snapshot: true
+    },
     "should include `idFields` in the client instantiation if options are not provided": {
       code: `
         import createClient from "@grafoo/core";

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "babel-literal-to-ast": "^2.0.0",
     "graphql": "^14.1.1",
-    "graphql-query-compress": "^1.0.0"
+    "graphql-query-compress": "^1.0.0",
+    "hash.js": "^1.1.7"
   },
   "gitHead": "0bc67d8b398884a1f387a1813e485d2c5318b974",
   "devDependencies": {

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -38,9 +38,9 @@
   },
   "dependencies": {
     "babel-literal-to-ast": "^2.0.0",
+    "crypto-js": "^3.1.9-1",
     "graphql": "^14.1.1",
-    "graphql-query-compress": "^1.0.0",
-    "hash.js": "^1.1.7"
+    "graphql-query-compress": "^1.0.0"
   },
   "gitHead": "0bc67d8b398884a1f387a1813e485d2c5318b974",
   "devDependencies": {

--- a/packages/babel-plugin/readme.md
+++ b/packages/babel-plugin/readme.md
@@ -60,7 +60,8 @@ To configure the plugin is required to specify the option `idFields`, an array o
       "@grafoo/babel-plugin",
       {
         "schema": "schema.graphql",
-        "idFields": ["id"]
+        "idFields": ["id"],
+        "generateIds": false
       }
     ]
   ]
@@ -111,7 +112,7 @@ The recommendation for now is to use the [`get-graphql-schema`](https://github.c
 -   }
 - `;
 + const USER_QUERY = {
-+   id: "f333c47eac309ba042dfc0cbd0293e210f5cd48f9d7015d988bcb621b61207d5",
++   id: "d4b567cd2a8891aa4cd1840f1a53002e", // only if option "generateIds" is true
 +   query: "query($id: ID!) { user(id: $id) { id name posts { id title } } }",
 +   paths: {
 +     "user(id:$id){id name posts{id title}}": {

--- a/packages/babel-plugin/readme.md
+++ b/packages/babel-plugin/readme.md
@@ -111,6 +111,7 @@ The recommendation for now is to use the [`get-graphql-schema`](https://github.c
 -   }
 - `;
 + const USER_QUERY = {
++   id: "f333c47eac309ba042dfc0cbd0293e210f5cd48f9d7015d988bcb621b61207d5",
 +   query: "query($id: ID!) { user(id: $id) { id name posts { id title } } }",
 +   paths: {
 +     "user(id:$id){id name posts{id title}}": {

--- a/packages/babel-plugin/src/compile-document.js
+++ b/packages/babel-plugin/src/compile-document.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { parse, print } from "graphql";
 import compress from "graphql-query-compress";
-import sha256 from "hash.js/lib/hash/sha/256";
+import md5Hash from "crypto-js/md5";
 import path from "path";
 import insertFields from "./insert-fields";
 import sortDocument from "./sort-query";
@@ -59,11 +59,10 @@ export default function compileDocument(source, opts) {
     // query has different whitespaces, newlines, etc
     // Document is also sorted by "sortDocument" therefore
     // selections, fields, etc order shouldn't matter either
-    const hash = sha256()
-      .update(compressed)
-      .digest("hex");
+    if (opts.generateIds) {
+      grafooObj.id = md5Hash(compressed).toString();
+    }
 
-    grafooObj.id = hash;
     grafooObj.query = opts.compress ? compressed : printed;
 
     grafooObj.paths = oprs[0].selectionSet.selections.reduce(

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -12,6 +12,10 @@ export default function transform({ types: t }) {
           opts.compress = process.env.NODE_ENV === "production";
         }
 
+        if (typeof opts.generateIds !== "boolean") {
+          opts.generateIds = false;
+        }
+
         if (!opts.idFields) {
           throw new Error("@grafoo/babel-plugin: the `idFields` option is required.");
         }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,10 +19,10 @@ export default function createClient(
   let { pathsMap, objectsMap } = initialState || { pathsMap: {}, objectsMap: {} };
   let listeners: Listener[] = [];
 
-  function execute<T>({ query, frags }: GrafooObject, variables?: Variables) {
+  function execute<T>({ query, frags, id }: GrafooObject, variables?: Variables) {
     if (frags) for (let frag in frags) query += frags[frag];
 
-    return transport<T>(query, variables);
+    return transport<T>(query, variables, id);
   }
 
   function listen(listener: Listener) {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -26,7 +26,7 @@ export interface Variables {
 export type GrafooTransport = <T>(
   query: string,
   variables?: Variables,
-  id: string
+  id?: string
 ) => Promise<GraphQlPayload<T>>;
 
 /**
@@ -82,7 +82,7 @@ export interface GrafooObject {
     };
   };
   query: string;
-  id: string;
+  id?: string;
 }
 
 /**

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -25,7 +25,8 @@ export interface Variables {
  */
 export type GrafooTransport = <T>(
   query: string,
-  variables?: Variables
+  variables?: Variables,
+  id: string
 ) => Promise<GraphQlPayload<T>>;
 
 /**
@@ -81,6 +82,7 @@ export interface GrafooObject {
     };
   };
   query: string;
+  id: string;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,6 +2685,11 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+crypto-js@^3.1.9-1:
+  version "3.1.9-1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
+  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
@@ -4044,14 +4049,6 @@ has@^1.0.1, has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
-
-hash.js@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.1"
 
 home-or-tmp@^3.0.0:
   version "3.0.0"
@@ -5734,11 +5731,6 @@ mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
-
-minimalistic-assert@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
-  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4045,6 +4045,14 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash.js@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 home-or-tmp@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-3.0.0.tgz#57a8fe24cf33cdd524860a15821ddc25c86671fb"
@@ -5726,6 +5734,11 @@ mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+minimalistic-assert@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Generate and add id (sha256 + hex digest) to query object and pass it to fetch function.

```js
// current object
const QUERY = {
  query: "query($id: ID!) { user(id: $id) { id name posts { id title } } }",
  paths: {
    "user(id:$id){id name posts{id title}}": {
      name: "user"
      args: ["id"]
    }
  }
};

// after this PR
const QUERY = {
  id: "f333c47eac309ba042dfc0cbd0293e210f5cd48f9d7015d988bcb621b61207d5",
  query: "query($id: ID!) { user(id: $id) { id name posts { id title } } }",
  paths: {
    "user(id:$id){id name posts{id title}}": {
      name: "user"
      args: ["id"]
    }
  }
};
```

Characteristics:
* sha256 output has fixed length, input size doesn't matter at all
* sha256 collision chance is ridiculously small, even if used for millions of objects
* sha256 always outputs the same hash for same input
* compressed version of query is passed to sha256, whitespace and newlines shouldn't matter
* query is also sorted (fields, args, etc), even different order shouldn't matter (**not tested**)

---

This PR should enable us to implement other PRs such as:

## Persisted queries  

This is actually already possible when this PR lands but you'd have to manually collect all client queries to single file. For this exact reason I decided to not document `id` variable passed to fetch function yet. 

#### Client example: 

```js
function fetchQuery(query, variables, id) {
  const init = {
    method: "POST",
    // don't add query, add id
    body: JSON.stringify({ id, variables }),
    headers: {
      "content-type": "application/json"
    }
  };

  return fetch("http://some.graphql.api", init).then(res => res.json());
}
```

#### Server example: 

```js
// Node.js
function processGraphQLRequest({query, variables, id}) {
  if (id) {
    // map id to query
    // example map (collected client queries to single object):
    const queries = { 
      'query-id-1': 'query Greeting { hello }',
      'query-id-2': 'query Reports { reports { id title amount } }'
    };
    const persistedQuery = queries[id];
    if (!persistedQuery) {
      // no query, do something about it
    }
    // pass persistedQuery to graphql-js
  } else if (query) {
    // pass query to graphql-js
  } else {
    // something is wrong, id and query are both missing!
  }
}
```

Im looking into this but I've never made a Babel plugin myself and Im not familiar with its lifecycle. Query objects have to be collected to global object and if plugin is done, write `JSON.stringify(obj, null, 2)` to JSON file, use `opts.output` or something similar for location and file name. But this is still a theory.   


## Use hashes elsewhere

For example we could hash selections too and replace query string based keys which get weird with huge queries and Im not sure if and how it would affect performance when cache gets big (e.g mobiles). 

---

# Tests

Are current tests sufficient? Coverage remained the same. 